### PR TITLE
Simplify examples by updating to new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ Once [installed](#install), you can use the following code to process an example
 user lists by sending a (RESTful) HTTP API request for each user record:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $concurrency = isset($argv[1]) ? $argv[1] : 3;
 
@@ -99,8 +98,7 @@ $transformer = new Transformer($concurrency, function ($user) use ($browser) {
 // load a huge number of users to process from NDJSON file
 $input = new Clue\React\NDJson\Decoder(
     new React\Stream\ReadableResourceStream(
-        fopen(__DIR__ . '/users.ndjson', 'r'),
-        $loop
+        fopen(__DIR__ . '/users.ndjson', 'r')
     ),
     true
 );
@@ -117,7 +115,6 @@ $transformer->on('end', function () {
 });
 $transformer->on('error', 'printf');
 
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -201,8 +198,7 @@ For demonstration purposes, the examples in this documentation use
 Its API can be used like this:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $promise = $browser->get($url);
 ```
@@ -211,8 +207,7 @@ If you wrap this in a `Transformer` instance as given above, this code will look
 like this:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $transformer = new Transformer(10, function ($url) use ($browser) {
     return $browser->get($url);
@@ -287,8 +282,8 @@ The resulting code with timeouts applied look something like this:
 ```php
 use React\Promise\Timer;
 
-$transformer = new Transformer(10, function ($uri) use ($browser, $loop) {
-    return Timer\timeout($browser->get($uri), 2.0, $loop);
+$transformer = new Transformer(10, function ($uri) use ($browser) {
+    return Timer\timeout($browser->get($uri), 2.0);
 });
 
 $transformer->write($uri);
@@ -326,8 +321,7 @@ The following examples use an async (non-blocking) transformation handler as
 given above:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $transformer = new Transformer(10, function ($url) use ($browser) {
     return $browser->get($url);
@@ -453,8 +447,7 @@ a promise which resolves with the total number of all successful jobs
 on success.
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $promise = Transformer::all($input, 3, function ($data) use ($browser, $url) {
     return $browser->post($url, [], json_encode($data));
@@ -559,8 +552,7 @@ a promise which resolves with the first successful resolution value on
 success.
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $promise = Transformer::any($input, 3, function ($data) use ($browser, $url) {
     return $browser->post($url, [], json_encode($data));

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     },
     "require": {
         "react/promise": "^2.5 || ^1.2.1",
-        "react/stream": "^1.0 || ^0.7.7"
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "clue/ndjson-react": "^1.0",
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
-        "react/http": "^1.0"
+        "react/http": "^1.4"
     }
 }

--- a/examples/01-transform.php
+++ b/examples/01-transform.php
@@ -5,8 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $concurrency = isset($argv[1]) ? $argv[1] : 3;
 
@@ -35,8 +34,7 @@ $transformer = new Transformer($concurrency, function ($user) use ($browser) {
 // load a huge number of users to process from NDJSON file
 $input = new Clue\React\NDJson\Decoder(
     new React\Stream\ReadableResourceStream(
-        fopen(__DIR__ . '/users.ndjson', 'r'),
-        $loop
+        fopen(__DIR__ . '/users.ndjson', 'r')
     ),
     true
 );
@@ -53,4 +51,3 @@ $transformer->on('end', function () {
 });
 $transformer->on('error', 'printf');
 
-$loop->run();

--- a/examples/02-transform-all.php
+++ b/examples/02-transform-all.php
@@ -5,8 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $concurrency = isset($argv[1]) ? $argv[1] : 3;
 $url = isset($argv[2]) ? $argv[2] : 'http://httpbin.org/post';
@@ -14,8 +13,7 @@ $url = isset($argv[2]) ? $argv[2] : 'http://httpbin.org/post';
 // load a huge number of users to process from NDJSON file
 $input = new Clue\React\NDJson\Decoder(
     new React\Stream\ReadableResourceStream(
-        fopen(__DIR__ . '/users.ndjson', 'r'),
-        $loop
+        fopen(__DIR__ . '/users.ndjson', 'r')
     ),
     true
 );
@@ -49,4 +47,3 @@ $promise->then(
     }
 );
 
-$loop->run();

--- a/examples/03-transform-any.php
+++ b/examples/03-transform-any.php
@@ -5,8 +5,7 @@ use Psr\Http\Message\ResponseInterface;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$browser = new React\Http\Browser($loop);
+$browser = new React\Http\Browser();
 
 $concurrency = isset($argv[1]) ? $argv[1] : 3;
 $url = isset($argv[2]) ? $argv[2] : 'http://httpbin.org/post';
@@ -14,8 +13,7 @@ $url = isset($argv[2]) ? $argv[2] : 'http://httpbin.org/post';
 // load a huge number of users to process from NDJSON file
 $input = new Clue\React\NDJson\Decoder(
     new React\Stream\ReadableResourceStream(
-        fopen(__DIR__ . '/users.ndjson', 'r'),
-        $loop
+        fopen(__DIR__ . '/users.ndjson', 'r')
     ),
     true
 );
@@ -53,4 +51,3 @@ $promise->then(
     }
 );
 
-$loop->run();

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -45,8 +45,7 @@ use React\Promise\PromiseInterface;
  * Its API can be used like this:
  *
  * ```php
- * $loop = React\EventLoop\Factory::create();
- * $browser = new React\Http\Browser($loop);
+ * $browser = new React\Http\Browser();
  *
  * $promise = $browser->get($url);
  * ```
@@ -55,8 +54,7 @@ use React\Promise\PromiseInterface;
  * like this:
  *
  * ```php
- * $loop = React\EventLoop\Factory::create();
- * $browser = new React\Http\Browser($loop);
+ * $browser = new React\Http\Browser();
  *
  * $transformer = new Transformer(10, function ($url) use ($browser) {
  *     return $browser->get($url);
@@ -131,8 +129,8 @@ use React\Promise\PromiseInterface;
  * ```php
  * use React\Promise\Timer;
  *
- * $transformer = new Transformer(10, function ($uri) use ($browser, $loop) {
- *     return Timer\timeout($browser->get($uri), 2.0, $loop);
+ * $transformer = new Transformer(10, function ($uri) use ($browser) {
+ *     return Timer\timeout($browser->get($uri), 2.0);
  * });
  *
  * $transformer->write($uri);
@@ -170,8 +168,7 @@ use React\Promise\PromiseInterface;
  * given above:
  *
  * ```php
- * $loop = React\EventLoop\Factory::create();
- * $browser = new React\Http\Browser($loop);
+ * $browser = new React\Http\Browser();
  *
  * $transformer = new Transformer(10, function ($url) use ($browser) {
  *     return $browser->get($url);
@@ -310,8 +307,7 @@ final class Transformer extends EventEmitter implements DuplexStreamInterface
      * on success.
      *
      * ```php
-     * $loop = React\EventLoop\Factory::create();
-     * $browser = new React\Http\Browser($loop);
+     * $browser = new React\Http\Browser();
      *
      * $promise = Transformer::all($input, 3, function ($data) use ($browser, $url) {
      *     return $browser->post($url, [], json_encode($data));
@@ -463,8 +459,7 @@ final class Transformer extends EventEmitter implements DuplexStreamInterface
      * success.
      *
      * ```php
-     * $loop = React\EventLoop\Factory::create();
-     * $browser = new React\Http\Browser($loop);
+     * $browser = new React\Http\Browser();
      *
      * $promise = Transformer::any($input, 3, function ($data) use ($browser, $url) {
      *     return $browser->post($url, [], json_encode($data));


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).
Builds on top of reactphp/event-loop#232, reactphp/stream#159, https://github.com/reactphp/http/pull/410