### PR TITLE
Fix typos in documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by individually sending a (RESTful) HTTP API request to some third party API
 for each record. Estimating each call to take around `0.3s` means that having
 `10000` users processed sequentially, you would have to wait around 50 minutes
 for all jobs to complete. This works perfectly fine for a small number of
-operations, but keeping thousands of jobs in memory at once may easly take up
+operations, but keeping thousands of jobs in memory at once may easily take up
 all resources on your side.
 Instead, you can use this library to stream your arbitrarily large input list
 as individual records to a non-blocking (async) transformation handler. It uses
@@ -141,7 +141,7 @@ also takes care of mangaging streaming throughput and back-pressure.
 The transformation handler can be any non-blocking (async) callable that uses
 [promises](#promises) to signal its eventual results. This callable receives
 a single data argument as passed to the writable side and must return a
-promise. A succesful fulfillment value will be forwarded to the readable end
+promise. A successful fulfillment value will be forwarded to the readable end
 of the stream, while an unsuccessful rejection value will emit an `error`
 event and then `close()` the stream.
 
@@ -306,7 +306,7 @@ passed through its transformation handler which is responsible for processing
 and transforming this data (see above for more details).
 
 The `Transformer` takes care of passing data you pass on its writable side to
-the transformation handler argument and forwarding resuling data to it
+the transformation handler argument and forwarding resulting data to it
 readable end.
 Each operation may take some time to complete, but due to its async nature you
 can actually start any number of (queued) operations. Once the concurrency limit
@@ -341,7 +341,7 @@ $transformer->write('http://example.com/');
 ```
 
 This handler receives a single data argument as passed to the writable side
-and must return a promise. A succesful fulfillment value will be forwarded to
+and must return a promise. A successful fulfillment value will be forwarded to
 the readable end of the stream, while an unsuccessful rejection value will
 emit an `error` event, try to `cancel()` all pending operations and then
 `close()` the stream.

--- a/examples/02-transform-all.php
+++ b/examples/02-transform-all.php
@@ -40,7 +40,7 @@ $promise->then(
         echo 'Successfully processed all ' . $count . ' user records' . PHP_EOL;
     },
     function (Exception $e) {
-        echo 'An error occured: ' . $e->getMessage() . PHP_EOL;
+        echo 'An error occurred: ' . $e->getMessage() . PHP_EOL;
         if ($e->getPrevious()) {
             echo 'Previous: ' . $e->getPrevious()->getMessage() . PHP_EOL;
         }

--- a/examples/03-transform-any.php
+++ b/examples/03-transform-any.php
@@ -44,7 +44,7 @@ $promise->then(
         echo 'Successfully processed user record:' . print_r($user, true) . PHP_EOL;
     },
     function (Exception $e) {
-        echo 'An error occured: ' . $e->getMessage() . PHP_EOL;
+        echo 'An error occurred: ' . $e->getMessage() . PHP_EOL;
         if ($e->getPrevious()) {
             echo 'Previous: ' . $e->getPrevious()->getMessage() . PHP_EOL;
         }

--- a/examples/users.ndjson
+++ b/examples/users.ndjson
@@ -6,5 +6,5 @@
 { "name": "sixth",   "birthday": "1962-01-01", "ip": "6.1.1.1" }
 { "name": "seventh", "birthday": "1951-01-01", "ip": "7.1.1.1" }
 { "name": "eighth",  "birthday": "1940-01-01", "ip": "8.1.1.1" }
-{ "name": "nineth",  "birthday": "1939-01-01", "ip": "9.1.1.1" }
+{ "name": "ninth",   "birthday": "1939-01-01", "ip": "9.1.1.1" }
 { "name": "tenth",   "birthday": "1928-01-01" }

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -26,7 +26,7 @@ use React\Promise\PromiseInterface;
  * The transformation handler can be any non-blocking (async) callable that uses
  * [promises](#promises) to signal its eventual results. This callable receives
  * a single data argument as passed to the writable side and must return a
- * promise. A succesful fulfillment value will be forwarded to the readable end
+ * promise. A successful fulfillment value will be forwarded to the readable end
  * of the stream, while an unsuccessful rejection value will emit an `error`
  * event and then `close()` the stream.
  *
@@ -151,7 +151,7 @@ use React\Promise\PromiseInterface;
  * and transforming this data (see above for more details).
  *
  * The `Transformer` takes care of passing data you pass on its writable side to
- * the transformation handler argument and forwarding resuling data to it
+ * the transformation handler argument and forwarding resulting data to it
  * readable end.
  * Each operation may take some time to complete, but due to its async nature you
  * can actually start any number of (queued) operations. Once the concurrency limit
@@ -186,7 +186,7 @@ use React\Promise\PromiseInterface;
  * ```
  *
  * The handler receives a single data argument as passed to the writable side
- * and must return a promise. A succesful fulfillment value will be forwarded to
+ * and must return a promise. A successful fulfillment value will be forwarded to
  * the readable end of the stream, while an unsuccessful rejection value will
  * emit an `error` event, try to `cancel()` all pending operations and then
  * `close()` the stream.


### PR DESCRIPTION
This pull request fixes a few typos with the help of https://github.com/szepeviktor/typos-on-you.

Builds on top of #7.